### PR TITLE
Fix svelte snippets path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
       },
       {
         "language": "svelte",
-        "path": "./snippets/css.code-snippets"
+        "path": "./snippets/snippets.code-snippets"
       }
     ],
     "commands": [


### PR DESCRIPTION
Snippets didn't work in *.svelte file. There was a small bug that directed to css and not to snippets.