### PR TITLE
Fix deprecated classes

### DIFF
--- a/src/templates/bs5/$.html
+++ b/src/templates/bs5/$.html
@@ -9,7 +9,7 @@
 			content="width=device-width, initial-scale=1, shrink-to-fit=no"
 		/>
 
-		<!-- Bootstrap CSS v5.2.1 -->
+		<!-- Bootstrap CSS v5.3.2 -->
 		<link
 			href="${2:https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css}"
 			rel="stylesheet"

--- a/src/templates/bs5/components/card/head-foot.html
+++ b/src/templates/bs5/components/card/head-foot.html
@@ -4,5 +4,5 @@
 		<h4 class="card-title">${2:Title}</h4>
 		<p class="card-text">${3:Text}</p>
 	</div>
-	<div class="card-footer text-muted">${4:Footer}</div>
+	<div class="card-footer text-body-secondary">${4:Footer}</div>
 </div>

--- a/src/templates/bs5/components/card/horizontal.html
+++ b/src/templates/bs5/components/card/horizontal.html
@@ -16,7 +16,7 @@
 					little bit longer.}
 				</p>
 				<p class="card-text">
-					<small class="text-muted"
+					<small class="text-body-secondary"
 						>${8:Last updated 3 mins ago}</small
 					>
 				</p>

--- a/src/templates/bs5/components/card/subtitle.html
+++ b/src/templates/bs5/components/card/subtitle.html
@@ -1,7 +1,7 @@
 <div class="card">
 	<div class="card-body">
 		<h4 class="card-title">${1:Title}</h4>
-		<h6 class="card-subtitle text-muted">${2:Subtitle}</h6>
+		<h6 class="card-subtitle text-body-secondary">${2:Subtitle}</h6>
 	</div>
 	<img src="${3:holder.js/100x180/}" alt="$4" />
 	<div class="card-body">

--- a/src/templates/bs5/components/form/email.html
+++ b/src/templates/bs5/components/form/email.html
@@ -8,7 +8,7 @@
 		aria-describedby="${4:emailHelpId}"
 		placeholder="${2:abc@mail.com}"
 	/>
-	<small id="${4:emailHelpId}" class="form-text text-muted"
+	<small id="${4:emailHelpId}" class="form-text text-body-secondary"
 		>${5:Help text}</small
 	>
 </div>

--- a/src/templates/bs5/components/form/group.html
+++ b/src/templates/bs5/components/form/group.html
@@ -8,5 +8,5 @@
 		placeholder="$2"
 		aria-describedby="${5:helpId}"
 	/>
-	<small id="${5:helpId}" class="text-muted">${6:Help text}</small>
+	<small id="${5:helpId}" class="text-body-secondary">${6:Help text}</small>
 </div>

--- a/src/templates/bs5/components/form/help-text-inline.html
+++ b/src/templates/bs5/components/form/help-text-inline.html
@@ -1,1 +1,1 @@
-<small class="text-muted">${1:Help Text}</small>
+<small class="text-body-secondary">${1:Help Text}</small>

--- a/src/templates/bs5/components/form/help-text.html
+++ b/src/templates/bs5/components/form/help-text.html
@@ -1,1 +1,1 @@
-<p class="form-text text-muted">${1:Help Text}</p>
+<p class="form-text text-body-secondary">${1:Help Text}</p>

--- a/src/templates/bs5/components/form/inline.html
+++ b/src/templates/bs5/components/form/inline.html
@@ -10,7 +10,7 @@
 				placeholder="$2"
 				aria-describedby="${5:helpId}"
 			/>
-			<small id="${5:helpId}" class="text-muted">${6:Help text}</small>
+			<small id="${5:helpId}" class="text-body-secondary">${6:Help text}</small>
 		</div>
 	</div>
 </form>

--- a/src/templates/bs5/components/form/input-sizing.html
+++ b/src/templates/bs5/components/form/input-sizing.html
@@ -8,5 +8,5 @@
 		aria-describedby="${6:helpId}"
 		placeholder="$2"
 	/>
-	<small id="${6:helpId}" class="form-text text-muted">${7:Help text}</small>
+	<small id="${6:helpId}" class="form-text text-body-secondary">${7:Help text}</small>
 </div>

--- a/src/templates/bs5/components/form/input.html
+++ b/src/templates/bs5/components/form/input.html
@@ -8,5 +8,5 @@
 		aria-describedby="${5:helpId}"
 		placeholder="$2"
 	/>
-	<small id="${5:helpId}" class="form-text text-muted">${6:Help text}</small>
+	<small id="${5:helpId}" class="form-text text-body-secondary">${6:Help text}</small>
 </div>

--- a/src/templates/bs5/components/list/custom.html
+++ b/src/templates/bs5/components/list/custom.html
@@ -6,10 +6,10 @@
 	>
 		<div class="d-flex w-100 justify-content-between">
 			<h5 class="mb-1">${2:Heading}</h5>
-			<small class="text-muted">${3:Description}</small>
+			<small class="text-body-secondary">${3:Description}</small>
 		</div>
 		<p class="mb-1">${4:Paragraph}</p>
-		<small class="text-muted">${5:paragraph footer}</small>
+		<small class="text-body-secondary">${5:paragraph footer}</small>
 	</a>
 	<a
 		href="${6:#}"
@@ -17,10 +17,10 @@
 	>
 		<div class="d-flex w-100 justify-content-between">
 			<h5 class="mb-1">${7:Heading}</h5>
-			<small class="text-muted">${8:Description}</small>
+			<small class="text-body-secondary">${8:Description}</small>
 		</div>
 		<p class="mb-1">${9:Paragraph}</p>
-		<small class="text-muted">${10:paragraph footer}</small>
+		<small class="text-body-secondary">${10:paragraph footer}</small>
 	</a>
 	<a
 		href="${11:#}"
@@ -28,9 +28,9 @@
 	>
 		<div class="d-flex w-100 justify-content-between">
 			<h5 class="mb-1">${12:Heading}</h5>
-			<small class="text-muted">${13:Description}</small>
+			<small class="text-body-secondary">${13:Description}</small>
 		</div>
 		<p class="mb-1">${14:Paragraph}</p>
-		<small class="text-muted">${15:paragraph footer}</small>
+		<small class="text-body-secondary">${15:paragraph footer}</small>
 	</a>
 </div>

--- a/src/templates/bs5/components/navbar/background-color.html
+++ b/src/templates/bs5/components/navbar/background-color.html
@@ -1,5 +1,6 @@
 <nav
-	class="navbar ${1|navbar-expand-sm,navbar-expand-md,navbar-expand-lg,navbar-expand-xl,navbar-expand-xxl|} ${2|navbar-dark,navbar-light|}"
+	class="navbar ${1|navbar-expand-sm,navbar-expand-md,navbar-expand-lg,navbar-expand-xl,navbar-expand-xxl|}"
+	data-bs-theme="${2:dark,light|}"
 	style="
 		background-color: $ {
 			3: #e3f2fd;

--- a/src/templates/bs5/components/navbar/background-color.html
+++ b/src/templates/bs5/components/navbar/background-color.html
@@ -1,6 +1,6 @@
 <nav
 	class="navbar ${1|navbar-expand-sm,navbar-expand-md,navbar-expand-lg,navbar-expand-xl,navbar-expand-xxl|}"
-	data-bs-theme="${2:dark,light|}"
+	data-bs-theme="${2|dark,light|}"
 	style="
 		background-color: $ {
 			3: #e3f2fd;

--- a/src/templates/bs5/components/navbar/background.html
+++ b/src/templates/bs5/components/navbar/background.html
@@ -1,5 +1,6 @@
 <nav
-	class="navbar ${1|navbar-expand-sm,navbar-expand-md,navbar-expand-lg,navbar-expand-xl,navbar-expand-xxl|} ${2|navbar-dark,navbar-light|} ${3|bg-primary,bg-secondary,bg-success,bg-danger,bg-warning,bg-info,bg-light,bg-dark|}"
+	class="navbar ${1|navbar-expand-sm,navbar-expand-md,navbar-expand-lg,navbar-expand-xl,navbar-expand-xxl|} ${3|bg-primary,bg-secondary,bg-success,bg-danger,bg-warning,bg-info,bg-light,bg-dark|}"
+	data-bs-theme="${2:dark,light|}"
 >
 	<a class="navbar-brand" href="${5:#}">${4|Navbar,img|}</a>
 	<button

--- a/src/templates/bs5/components/navbar/default.html
+++ b/src/templates/bs5/components/navbar/default.html
@@ -1,5 +1,5 @@
 <nav
-	class="navbar ${1|navbar-expand-sm,navbar-expand-md,navbar-expand-lg,navbar-expand-xl,navbar-expand-xxl|} navbar-light bg-light"
+	class="navbar ${1|navbar-expand-sm,navbar-expand-md,navbar-expand-lg,navbar-expand-xl,navbar-expand-xxl|}"
 >
 	<div class="container">
 		<a class="navbar-brand" href="${3:#}">${2|Navbar,img|}</a>

--- a/src/templates/bs5/components/navbar/minimal-a.html
+++ b/src/templates/bs5/components/navbar/minimal-a.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand navbar-light bg-light">
+<nav class="navbar navbar-expand">
 	<div class="nav navbar-nav">
 		<a class="nav-item nav-link active" href="${2:#}" aria-current="page"
 			>${1:Home} <span class="visually-hidden">(current)</span></a

--- a/src/templates/bs5/components/navbar/minimal-ul.html
+++ b/src/templates/bs5/components/navbar/minimal-ul.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand navbar-light bg-light">
+<nav class="navbar navbar-expand">
 	<ul class="nav navbar-nav">
 		<li class="nav-item">
 			<a class="nav-link active" href="${2:#}" aria-current="page"

--- a/src/templates/bs5/components/navbar/non-responsive.html
+++ b/src/templates/bs5/components/navbar/non-responsive.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand navbar-light bg-faded">
+<nav class="navbar navbar-expand">
 	<div class="container">
 		<a class="navbar-brand" href="${2:#}">${1|Navbar,img|}</a>
 		<ul class="navbar-nav me-auto mt-2 mt-lg-0">

--- a/src/templates/bs5/components/navbar/offcanvas.html
+++ b/src/templates/bs5/components/navbar/offcanvas.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-light bg-light fixed-top">
+<nav class="navbar fixed-top">
 	<div class="container-fluid">
 		<a class="navbar-brand" href="${2:#}">${1|Navbar,img|}</a>
 		<button

--- a/src/templates/bs5/components/navbar/placement.html
+++ b/src/templates/bs5/components/navbar/placement.html
@@ -1,5 +1,5 @@
 <nav
-	class="navbar navbar-expand-lg navbar-light bg-light ${1|fixed-top,fixed-bottom,sticky-top|}"
+	class="navbar navbar-expand-lg ${1|fixed-top,fixed-bottom,sticky-top|}"
 >
 	<div class="container">
 		<a class="navbar-brand" href="${3:#}">${2|Navbar,img|}</a>

--- a/src/templates/bs5/components/toast/stacked.html
+++ b/src/templates/bs5/components/toast/stacked.html
@@ -3,7 +3,7 @@
 		<div class="toast-header">
 			<img src="${1:source}" class="rounded me-2" alt="${2:Bootstrap}" />
 			<strong class="me-auto">${2:Bootstrap}</strong>
-			<small class="text-muted">${3:just now}</small>
+			<small class="text-body-secondary">${3:just now}</small>
 			<button
 				type="button"
 				class="btn-close"
@@ -22,7 +22,7 @@
 				alt="${6:Bootstrap 2}"
 			/>
 			<strong class="me-auto">${6:Bootstrap 2}</strong>
-			<small class="text-muted">${7:just now}</small>
+			<small class="text-body-secondary">${7:just now}</small>
 			<button
 				type="button"
 				class="btn-close"


### PR DESCRIPTION
As of version[ 5.3.0 Alpha 1/2](https://getbootstrap.com/docs/5.3/migration), some classes were deprecated. The ones I could find that were used are `text-muted` and `navbar-dark/light`. 
I also removed `navbar-light bg-light` on navbars, as this is a default value and it would allow for compatibility with the dark theme. 